### PR TITLE
Data filtering manipulation

### DIFF
--- a/src/lib/components/csvParser/CsvParser.svelte
+++ b/src/lib/components/csvParser/CsvParser.svelte
@@ -106,6 +106,18 @@
 		currentPage = 1;
 	});
 
+	// Reset highlights and selections when switching files/tabs
+	$effect(() => {
+		$activeFileId; // subscribe to active tab
+		highlightedRows = new Set();
+		highlightedCells = new Set();
+		selectedRows = new Set();
+		selectedCell = null;
+		editingCell = null;
+		headerMenu = null;
+		// optionally: editMode = false;
+	});
+
 	// Keep numeric math robust if <select> binds as string
 	const startIndex = $derived(() => (Number(currentPage) - 1) * Number(pageSize));
 

--- a/src/lib/components/csvParser/CsvParser.svelte
+++ b/src/lib/components/csvParser/CsvParser.svelte
@@ -3,6 +3,7 @@
 	import { csvData, clearCSV } from '$lib/stores/csvData';
 	import { downloadCSVFromParsed } from '$lib/utils/csv/export';
 	import { activeFileId } from '$lib/stores/project';
+	import { goto } from '$app/navigation';
 
 	import delete_icon from '$lib/common/delete_icon.svg';
 	import CleanPanel from '$lib/components/CleanPanel/CleanPanel.svelte';
@@ -431,6 +432,10 @@
 			<button onclick={() => (showCleanMenu = true)} title="Data cleaning">
 				<span class="material-symbols-outlined">cleaning_services</span>
 				Clean
+			</button>
+			<button class="secondary" onclick={() => goto('/dataLab')} title="Open in Data Lab">
+				<span class="material-symbols-outlined">functions</span>
+				Data Lab
 			</button>
 		</div>
 	</div>

--- a/src/lib/components/dataLab/DataLab.svelte
+++ b/src/lib/components/dataLab/DataLab.svelte
@@ -1,0 +1,1070 @@
+<script lang="ts">
+	// Stores
+	import {
+		currentProject,
+		projectFiles,
+		activeFileId,
+		type ProjectFileMeta
+	} from '$lib/stores/project';
+	import { filesState, setFileState } from '$lib/stores/csvMulti';
+
+	// Types
+	import type { ParsedCSV, CellValue } from '$lib/stores/csvData';
+	import {
+		applyTransforms,
+		summarizeTransforms,
+		type Transform,
+		type FilterOp
+	} from '$lib/utils/datalab/transform';
+
+	// Working pipeline
+	let transforms = $state<Transform[]>([]);
+	let preview: ParsedCSV | null = $state(null);
+
+	// Builders
+	let filterColumn = $state<string | null>(null);
+	let filterOp = $state<FilterOp>('eq');
+	let filterValue = $state(''); // supports comma list for 'in'
+	let filterCase = $state(false);
+
+	let rowAvgCols = $state<string[]>([]);
+	let rowAvgOut = $state('avg');
+
+	let appendFileId = $state<string | null>(null);
+	let loadingOther = $state(false);
+
+	// Edit mode state
+	let editMode = $state(false);
+	let selectedCell = $state<{ rowLocal: number; header: string } | null>(null);
+	let editingCell = $state<{ rowLocal: number; header: string } | null>(null);
+
+	// Header context menu and rename state
+	let headerMenu = $state<{ header: string; x: number; y: number } | null>(null);
+	let headerMenuEl = $state<HTMLDivElement | null>(null);
+	let editingHeader = $state<string | null>(null);
+	let headerEditValue = $state('');
+
+	// Row selection for bulk deletion (absolute indices over current dataset; no pagination, so equals local)
+	let selectedRows = $state(new Set<number>());
+
+	// Derived helpers (plain expressions)
+	const baseData = $derived<ParsedCSV | null>(
+		$activeFileId ? ($filesState[$activeFileId] ?? null) : null
+	);
+	const headers = $derived<string[]>(baseData ? baseData.headers : []);
+	const files = $derived<ProjectFileMeta[]>($projectFiles);
+	const appendCandidates = $derived<ProjectFileMeta[]>(
+		files.filter((f: ProjectFileMeta) => f.file_id !== $activeFileId)
+	);
+
+	// What to show in the table (base vs preview)
+	const tableData = $derived<ParsedCSV | null>(editMode ? baseData : (preview ?? baseData));
+
+	// Pagination
+	let pageSize = $state(100); // user can change (50/100/200/300)
+	let currentPage = $state(1);
+	const totalPages = $derived<number>(
+		tableData ? Math.max(1, Math.ceil(tableData.rows.length / Number(pageSize))) : 1
+	);
+	const startIndex = $derived<number>((Number(currentPage) - 1) * Number(pageSize));
+	type Row = Record<string, CellValue>;
+	const paginatedRows = $derived.by<Row[]>(() =>
+		tableData
+			? tableData.rows.slice(
+					startIndex,
+					Math.min(startIndex + Number(pageSize), tableData.rows.length)
+				)
+			: []
+	);
+	// Absolute indices for current page
+	const pageIndices = () => {
+		if (!tableData) return [] as number[];
+		const start = startIndex;
+		const end = Math.min(startIndex + Number(pageSize), tableData.rows.length);
+		const len = Math.max(0, end - start);
+		return Array.from({ length: len }, (_, i) => start + i);
+	};
+	const selectedCount = $derived<number>(selectedRows.size);
+	function goToPage(p: number) {
+		if (p < 1) p = 1;
+		if (p > totalPages) p = totalPages;
+		currentPage = p;
+	}
+	// Reset/clamp when data or settings change
+	$effect(() => {
+		tableData;
+		currentPage = 1;
+	});
+	$effect(() => {
+		pageSize;
+		currentPage = 1;
+	});
+	$effect(() => {
+		if (currentPage > totalPages) currentPage = totalPages;
+	});
+
+	function addFilter() {
+		if (!filterColumn) return;
+		const t: Transform = {
+			kind: 'filterRows',
+			column: filterColumn,
+			op: filterOp,
+			value:
+				filterOp === 'in'
+					? filterValue
+							.split(',')
+							.map((s) => s.trim())
+							.filter(Boolean)
+					: filterValue,
+			caseSensitive: filterCase
+		};
+		transforms = [...transforms, t];
+		filterValue = '';
+	}
+
+	function addRowAvg() {
+		const cols = rowAvgCols.filter(Boolean);
+		if (cols.length === 0 || !rowAvgOut.trim()) return;
+		transforms = [
+			...transforms,
+			{ kind: 'rowAverage', columns: cols, outColumn: rowAvgOut.trim() }
+		];
+	}
+
+	// Append requires the other file to be already loaded into filesState
+	async function addAppend() {
+		if (!appendFileId) return;
+		if (!$currentProject) return;
+		const other = $filesState[appendFileId] as ParsedCSV | undefined;
+		if (!other) {
+			alert('Open the file tab once to load it, then try again.');
+			return;
+		}
+		transforms = [...transforms, { kind: 'appendFile', other }];
+	}
+
+	function removeTransform(idx: number) {
+		const copy = transforms.slice();
+		copy.splice(idx, 1);
+		transforms = copy;
+	}
+
+	function buildPreview() {
+		if (!baseData) {
+			preview = null;
+			return;
+		}
+		preview = applyTransforms(baseData, transforms);
+	}
+
+	async function saveAsNewTab() {
+		if (!$currentProject || !baseData) return;
+		const result = applyTransforms(baseData, transforms);
+		const name = summarizeTransforms(transforms) || 'Derived';
+		const res = await fetch(`/api/projects/${$currentProject.project_id}/files`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			credentials: 'same-origin',
+			body: JSON.stringify({
+				name: `${getDisplayName()} | ${name}`.slice(0, 120),
+				originalFilename: result.filename,
+				snapshot: result
+			})
+		});
+		if (!res.ok) return;
+		const created = await res.json();
+		setFileState(created.file_id, result);
+		await refreshFilesList();
+		activeFileId.set(created.file_id);
+	}
+
+	function getDisplayName() {
+		const cur = files.find((f) => f.file_id === $activeFileId);
+		return cur ? cur.name : 'Dataset';
+	}
+
+	async function refreshFilesList() {
+		if (!$currentProject) return;
+		const r = await fetch(`/api/projects/${$currentProject.project_id}/files`, {
+			credentials: 'same-origin'
+		});
+		if (!r.ok) return;
+		const data = await r.json();
+		projectFiles.set(data.files ?? []);
+	}
+
+	function toggleRowAvgCol(h: string) {
+		rowAvgCols = rowAvgCols.includes(h) ? rowAvgCols.filter((x) => x !== h) : [...rowAvgCols, h];
+	}
+
+	// Cell edit helpers
+	function handleCellClick(rowLocal: number, header: string) {
+		if (!editMode) return;
+		selectedCell = { rowLocal, header };
+		editingCell = { rowLocal, header };
+		headerMenu = null;
+	}
+
+	function inputId(rowLocal: number, header: string) {
+		return `datalab-cell-input-${rowLocal}-${header}`;
+	}
+
+	$effect(() => {
+		if (editingCell) {
+			const id = inputId(editingCell.rowLocal, editingCell.header);
+			queueMicrotask(() => {
+				const el = document.getElementById(id) as HTMLInputElement | null;
+				el?.focus();
+				el?.select();
+			});
+		}
+	});
+
+	function updateCell(localRowIndex: number, header: string, value: string) {
+		if (!$activeFileId) return;
+		const abs = startIndex + localRowIndex;
+		filesState.update((m) => {
+			const id = $activeFileId as string;
+			const d = m[id];
+			if (!d) return m;
+			const rows = d.rows.slice();
+			const next = { ...rows[abs], [header]: value === '' ? null : value };
+			rows[abs] = next;
+			return { ...m, [id]: { ...d, rows } };
+		});
+	}
+
+	// Row selection and bulk delete
+	function toggleRowChecked(localRowIndex: number, checked: boolean) {
+		if (!editMode) return;
+		const abs = startIndex + localRowIndex;
+		const next = new Set(selectedRows);
+		if (checked) next.add(abs);
+		else next.delete(abs);
+		selectedRows = next;
+	}
+	function clearSelection() {
+		selectedRows = new Set();
+	}
+	function deleteSelectedRows() {
+		if (!$activeFileId || selectedRows.size === 0) return;
+		filesState.update((m) => {
+			const id = $activeFileId as string;
+			const d = m[id];
+			if (!d) return m;
+			const keep = d.rows.filter((_, idx) => !selectedRows.has(idx));
+			return { ...m, [id]: { ...d, rows: keep } };
+		});
+		clearSelection();
+	}
+
+	// Select-all checkbox helpers (for displayed rows)
+	let selectAllRef = $state<HTMLInputElement | null>(null);
+	const selectAllChecked = $derived<boolean>(
+		pageIndices().length > 0 && pageIndices().every((i) => selectedRows.has(i))
+	);
+	const selectAllIndeterminate = $derived<boolean>(
+		pageIndices().some((i) => selectedRows.has(i)) && !selectAllChecked
+	);
+	function indeterminate(node: HTMLInputElement, value: boolean) {
+		node.indeterminate = value;
+		return {
+			update(v: boolean) {
+				node.indeterminate = v;
+			}
+		};
+	}
+	$effect(() => {
+		if (!selectAllRef) return;
+		(selectAllRef as HTMLInputElement).indeterminate = selectAllIndeterminate;
+		(selectAllRef as HTMLInputElement).checked = selectAllChecked;
+	});
+	function toggleSelectAllDisplayed(checked: boolean) {
+		if (!editMode) return;
+		const next = new Set(selectedRows);
+		const ids = pageIndices();
+		if (checked) ids.forEach((i) => next.add(i));
+		else ids.forEach((i) => next.delete(i));
+		selectedRows = next;
+	}
+
+	// Header context menu and rename/delete
+	function handleHeaderClick(h: string, evt: MouseEvent) {
+		if (!editMode) return;
+		evt.stopPropagation();
+		const gap = 8,
+			menuW = 200,
+			menuH = 90,
+			vw = window.innerWidth,
+			vh = window.innerHeight;
+		let x = evt.clientX + gap,
+			y = evt.clientY + gap;
+		if (x + menuW > vw) x = vw - menuW - gap;
+		if (y + menuH > vh) y = vh - menuH - gap;
+		headerMenu = { header: h, x, y };
+		selectedCell = null;
+		editingCell = null;
+	}
+	function swallowClick(e: MouseEvent) {
+		e.stopPropagation();
+	}
+	function headerInputId(name: string) {
+		return `datalab-header-input-${encodeURIComponent(name)}`;
+	}
+	function beginHeaderEdit(h: string) {
+		editingHeader = h;
+		headerEditValue = h;
+		headerMenu = null;
+	}
+	function commitHeaderRename(oldName: string, nextRaw: string) {
+		const next = (nextRaw || '').trim();
+		if (!next || next === oldName) {
+			editingHeader = null;
+			return;
+		}
+		if (!$activeFileId) {
+			editingHeader = null;
+			return;
+		}
+		filesState.update((m) => {
+			const id = $activeFileId as string;
+			const d = m[id];
+			if (!d || d.headers.includes(next)) return m;
+			const headers = d.headers.map((h) => (h === oldName ? next : h));
+			const rows = d.rows.map((r) => {
+				const { [oldName]: val, ...rest } = r;
+				return { ...rest, [next]: val ?? null };
+			});
+			return { ...m, [id]: { ...d, headers, rows } };
+		});
+		editingHeader = null;
+	}
+	function deleteColumn(name: string) {
+		if (!$activeFileId) return;
+		filesState.update((m) => {
+			const id = $activeFileId as string;
+			const d = m[id];
+			if (!d) return m;
+			const headers = d.headers.filter((h) => h !== name);
+			const rows = d.rows.map(({ [name]: _drop, ...rest }) => rest);
+			return { ...m, [id]: { ...d, headers, rows } };
+		});
+		headerMenu = null;
+	}
+
+	// Focus the header input when entering rename
+	$effect(() => {
+		if (editingHeader) {
+			const id = headerInputId(editingHeader);
+			queueMicrotask(() => {
+				const el = document.getElementById(id) as HTMLInputElement | null;
+				el?.focus();
+				el?.select();
+			});
+		}
+	});
+
+	// Add row/column helpers (manip toolbar)
+	let newColName = $state('');
+	function addEmptyRow() {
+		if (!$activeFileId) return;
+		filesState.update((m) => {
+			const id = $activeFileId as string;
+			const d = m[id];
+			if (!d) return m;
+			const empty = Object.fromEntries(d.headers.map((h) => [h, null] as const));
+			return { ...m, [id]: { ...d, rows: [...d.rows, empty] } };
+		});
+	}
+	function addColumn(name: string) {
+		const n = name.trim();
+		if (!n || !$activeFileId) return;
+		filesState.update((m) => {
+			const id = $activeFileId as string;
+			const d = m[id];
+			if (!d || d.headers.includes(n)) return m;
+			const headers = [...d.headers, n];
+			const rows = d.rows.map((r) => ({ ...r, [n]: null }));
+			return { ...m, [id]: { ...d, headers, rows } };
+		});
+		newColName = '';
+	}
+
+	// Focus first menu item when the header menu opens (same as CsvParser)
+	$effect(() => {
+		if (headerMenu) {
+			queueMicrotask(() => {
+				const firstBtn = headerMenuEl?.querySelector('button') as HTMLButtonElement | null;
+				firstBtn?.focus();
+			});
+		}
+	});
+
+	// Global key handling: Enter starts editing current cell; Escape closes menu/edit
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape' && headerMenu) {
+			headerMenu = null;
+			return;
+		}
+		if (!selectedCell) return;
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			editingCell = selectedCell;
+		} else if (e.key === 'Escape') {
+			editingCell = null;
+			selectedCell = null;
+		}
+	}
+
+	// Don’t open menu while renaming, or when clicking on inputs/buttons inside the cell
+	function onHeaderCellClick(h: string, evt: MouseEvent) {
+		if (editingHeader === h) return;
+		const target = evt.target as HTMLElement | null;
+		if (target?.closest('input,button')) return;
+		handleHeaderClick(h, evt); // positions the floating menu
+	}
+</script>
+
+<svelte:window onkeydown={onKey} onclick={() => (headerMenu = null)} />
+
+{#if !$activeFileId || !baseData}
+	<p>Open a dataset first (select a file tab), then come back to Data Lab.</p>
+{:else}
+	<div class="lab">
+		<div class="left">
+			<h2>Data Lab</h2>
+			<p class="hint">Compose filters and functions. Preview, then save as a new tab.</p>
+
+			<!-- Manipulation toolbar (edit mode only) -->
+			{#if editMode}
+				<div class="manip-toolbar">
+					<button class="primary add-row-btn" onclick={addEmptyRow}>
+						<span class="material-symbols-outlined">add</span>
+						Add row
+					</button>
+					<div class="add-col-group">
+						<input
+							class="add-col-input"
+							placeholder="New column name…"
+							bind:value={newColName}
+							autocomplete="off"
+							aria-label="New column name"
+						/>
+						<button
+							class="secondary add-col-btn"
+							onclick={() => addColumn(newColName)}
+							disabled={!newColName.trim()}
+						>
+							<span class="material-symbols-outlined">view_column</span>
+							Add column
+						</button>
+					</div>
+				</div>
+			{/if}
+
+			<section class="tool">
+				<h3>Filter rows</h3>
+				<div class="row">
+					<label>Column</label>
+					<select bind:value={filterColumn}>
+						<option value={null as any} disabled selected>Select column</option>
+						{#each headers as h}<option value={h}>{h}</option>{/each}
+					</select>
+				</div>
+				<div class="row">
+					<label>Operator</label>
+					<select bind:value={filterOp}>
+						<option value="eq">equals</option>
+						<option value="neq">not equals</option>
+						<option value="contains">contains</option>
+						<option value="in">in list</option>
+					</select>
+				</div>
+				<div class="row">
+					<label>{filterOp === 'in' ? 'Values (comma separated)' : 'Value'}</label>
+					<input bind:value={filterValue} placeholder={filterOp === 'in' ? 'a, b, c' : 'value'} />
+				</div>
+				<label class="inline">
+					<input
+						type="checkbox"
+						checked={filterCase}
+						onchange={(e) => (filterCase = (e.target as HTMLInputElement).checked)}
+					/>
+					Case sensitive
+				</label>
+				<div class="actions">
+					<button class="secondary" onclick={addFilter} disabled={!filterColumn}>Add filter</button>
+				</div>
+			</section>
+
+			<section class="tool">
+				<h3>Row average</h3>
+				<div class="cols">
+					{#each headers as h}
+						<label class="chk">
+							<input
+								type="checkbox"
+								checked={rowAvgCols.includes(h)}
+								onchange={() => toggleRowAvgCol(h)}
+							/>
+							<span>{h}</span>
+						</label>
+					{/each}
+				</div>
+				<div class="row">
+					<label>Output column</label>
+					<input bind:value={rowAvgOut} placeholder="avg" />
+				</div>
+				<div class="actions">
+					<button
+						class="secondary"
+						onclick={addRowAvg}
+						disabled={rowAvgCols.length === 0 || !rowAvgOut.trim()}
+					>
+						Add row average
+					</button>
+				</div>
+			</section>
+
+			<section class="tool">
+				<h3>Append another file</h3>
+				<select bind:value={appendFileId}>
+					<option value={null as any} disabled selected>Select file to append</option>
+					{#each appendCandidates as f}
+						<option value={f.file_id}>{f.name}</option>
+					{/each}
+				</select>
+				<div class="actions">
+					<button class="secondary" onclick={addAppend} disabled={!appendFileId || loadingOther}>
+						{loadingOther ? 'Loading…' : 'Add append'}
+					</button>
+				</div>
+			</section>
+
+			{#if transforms.length > 0}
+				<section class="pipeline">
+					<h3>Pipeline</h3>
+					<ul>
+						{#each transforms as t, i}
+							<li>
+								<span class="chip">{summarizeTransforms([t])}</span>
+								<button class="link" onclick={() => removeTransform(i)}>remove</button>
+							</li>
+						{/each}
+					</ul>
+				</section>
+				<div class="actions">
+					<button onclick={buildPreview} title="Apply transforms for preview">Preview</button>
+					<button class="primary" onclick={saveAsNewTab}>Save as new tab</button>
+				</div>
+			{/if}
+		</div>
+
+		<div class="right">
+			<div class="head">
+				<strong>{preview && !editMode ? 'Preview' : 'Dataset'}</strong>
+				<small class="muted">
+					{transforms.length ? summarizeTransforms(transforms) : 'No transforms yet'}
+				</small>
+				<div style="margin-top:6px; display:flex; gap:8px; align-items:center;">
+					<button
+						class="secondary"
+						onclick={() => (editMode = !editMode)}
+						aria-pressed={editMode}
+						disabled={!baseData || !!preview}
+					>
+						{editMode ? 'Editing (on)' : 'Edit mode'}
+					</button>
+					{#if preview && !editMode}
+						<small class="muted">Editing disabled while preview is active</small>
+					{/if}
+				</div>
+			</div>
+
+			{#if tableData}
+				<div class="pagination">
+					<div class="rows-group">
+						<label class="rows-label" for="rows-per-page">Rows per page:</label>
+						<select
+							id="rows-per-page"
+							class="rows-select"
+							bind:value={pageSize}
+							onchange={() => (currentPage = 1)}
+						>
+							<option value={50}>50</option>
+							<option value={100}>100</option>
+							<option value={200}>200</option>
+							<option value={300}>300</option>
+						</select>
+					</div>
+					<button onclick={() => goToPage(1)} disabled={currentPage === 1}>First</button>
+					<button onclick={() => goToPage(currentPage - 1)} disabled={currentPage === 1}
+						>Prev</button
+					>
+					<span>Page {currentPage} of {totalPages}</span>
+					<button onclick={() => goToPage(currentPage + 1)} disabled={currentPage === totalPages}
+						>Next</button
+					>
+					<button onclick={() => goToPage(totalPages)} disabled={currentPage === totalPages}
+						>Last</button
+					>
+				</div>
+			{/if}
+
+			<!-- Bulk toolbar -->
+			{#if editMode && selectedCount > 0}
+				<div class="bulk-toolbar">
+					<span
+						><strong>{selectedCount}</strong> {selectedCount === 1 ? 'row' : 'rows'} selected</span
+					>
+					<button class="danger" onclick={deleteSelectedRows} title="Delete selected rows">
+						<span class="material-symbols-outlined">delete</span>
+						Delete
+					</button>
+					<button class="link" onclick={clearSelection}>Clear selection</button>
+				</div>
+			{/if}
+
+			{#if tableData}
+				<div class="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								{#if editMode}
+									<th class="select-col">
+										<input
+											type="checkbox"
+											bind:this={selectAllRef}
+											checked={selectAllChecked}
+											use:indeterminate={selectAllIndeterminate}
+											onchange={(e) =>
+												toggleSelectAllDisplayed((e.target as HTMLInputElement).checked)}
+											aria-label="Select all rows on this page"
+										/>
+									</th>
+								{/if}
+								{#each tableData.headers as h}
+									<th
+										class="header-cell"
+										class:editing={editingHeader === h}
+										onclick={(e) => onHeaderCellClick(h, e)}
+									>
+										{#if editingHeader === h}
+											<input
+												id={headerInputId(h)}
+												class="header-input"
+												bind:value={headerEditValue}
+												onkeydown={(e) => {
+													if (e.key === 'Enter') commitHeaderRename(h, headerEditValue);
+													else if (e.key === 'Escape') editingHeader = null;
+												}}
+												onblur={() => commitHeaderRename(h, headerEditValue)}
+												aria-label="Rename column"
+											/>
+										{:else}
+											{h}
+										{/if}
+									</th>
+								{/each}
+							</tr>
+						</thead>
+						<tbody>
+							{#each paginatedRows as r, i}
+								<tr>
+									{#if editMode}
+										<td class="select-col">
+											<input
+												type="checkbox"
+												checked={selectedRows.has(startIndex + i)}
+												onchange={(e) =>
+													toggleRowChecked(i, (e.target as HTMLInputElement).checked)}
+												aria-label={`Select row ${startIndex + i + 1}`}
+											/>
+										</td>
+									{/if}
+									{#each tableData.headers as h}
+										<td
+											class:selected={selectedCell &&
+												selectedCell.rowLocal === i &&
+												selectedCell.header === h}
+											onclick={() => handleCellClick(i, h)}
+										>
+											{#if editMode && editingCell && editingCell.rowLocal === i && editingCell.header === h}
+												<input
+													id={inputId(i, h)}
+													value={r[h] ?? ''}
+													onkeydown={(e) => {
+														const val = (e.target as HTMLInputElement).value;
+														if (e.key === 'Enter') {
+															updateCell(i, h, val);
+															editingCell = null;
+															selectedCell = null;
+														} else if (e.key === 'Escape') {
+															editingCell = null;
+															selectedCell = null;
+														}
+													}}
+													onblur={(e) => {
+														updateCell(i, h, (e.target as HTMLInputElement).value);
+														editingCell = null;
+														selectedCell = null;
+													}}
+												/>
+											{:else}
+												{r[h] ?? ''}
+											{/if}
+										</td>
+									{/each}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+					<small class="muted">
+						Showing rows {tableData ? startIndex + 1 : 0}–
+						{tableData ? Math.min(startIndex + Number(pageSize), tableData.rows.length) : 0}
+						of {tableData ? tableData.rows.length : 0}
+					</small>
+				</div>
+			{:else}
+				<p class="muted">No data.</p>
+			{/if}
+
+			{#if headerMenu}
+				<!-- svelte-ignore a11y_interactive_supports_focus -->
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
+				<div
+					class="header-menu"
+					bind:this={headerMenuEl}
+					style={`left:${headerMenu.x}px; top:${headerMenu.y}px;`}
+					onclick={swallowClick}
+					role="menu"
+					aria-label={`Column ${headerMenu.header} actions`}
+				>
+					<button
+						type="button"
+						class="menu-item"
+						onclick={() => {
+							beginHeaderEdit(headerMenu!.header);
+						}}
+						role="menuitem"
+					>
+						<span class="material-symbols-outlined">edit</span>
+						Edit text
+					</button>
+					<button
+						type="button"
+						class="menu-item danger"
+						onclick={() => {
+							deleteColumn(headerMenu!.header);
+							headerMenu = null;
+						}}
+						role="menuitem"
+					>
+						<span class="material-symbols-outlined">delete</span>
+						Delete column
+					</button>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.lab {
+		display: flex;
+		gap: 16px;
+	}
+	.left {
+		width: 360px;
+		flex: 0 0 auto;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+	.right {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+	h2 {
+		margin: 0 0 4px;
+	}
+	.hint,
+	.muted {
+		color: #666;
+	}
+	.tool {
+		border: 1px solid #e6e6e6;
+		border-radius: 10px;
+		padding: 10px;
+		background: #fff;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+	}
+	.tool h3 {
+		margin: 0 0 6px;
+		font-size: 1rem;
+	}
+	.row {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+		margin: 6px 0;
+	}
+	.row > label {
+		min-width: 96px;
+		color: #333;
+	}
+	.inline {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-top: 4px;
+	}
+	.cols {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 6px;
+		max-height: 180px;
+		overflow: auto;
+		border: 1px solid #eee;
+		border-radius: 8px;
+		padding: 6px;
+	}
+	.chk {
+		display: flex;
+		gap: 6px;
+		align-items: center;
+	}
+	.pipeline ul {
+		margin: 4px 0;
+		padding: 0;
+		list-style: none;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.chip {
+		display: inline-block;
+		padding: 4px 8px;
+		border-radius: 999px;
+		background: #f5f7ff;
+		border: 1px solid #dbe2ff;
+		color: #123;
+		font-size: 0.85rem;
+	}
+	.link {
+		background: transparent;
+		border: none;
+		color: #0b5fff;
+		text-decoration: underline;
+		padding: 0 4px;
+		cursor: pointer;
+	}
+	.actions {
+		display: flex;
+		gap: 8px;
+		margin-top: 6px;
+	}
+	.head {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		margin-bottom: 6px;
+	}
+	.table-wrap {
+		border: 1px solid #e6e6e6;
+		border-radius: 10px;
+		overflow: auto;
+	}
+	table {
+		border-collapse: collapse;
+		width: 100%;
+		font-size: 0.9rem;
+		background: #fff;
+	}
+	th,
+	td {
+		border: 1px solid #eee;
+		padding: 4px 6px;
+		text-align: left;
+	}
+	th {
+		background: #f7f7f7;
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+	td.selected {
+		outline: 2px solid #4a90e2;
+		outline-offset: -2px;
+	}
+
+	.manip-toolbar {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+		align-items: center;
+		margin: 0.5rem 0 1rem 0;
+	}
+	.add-row-btn {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 1rem;
+		padding: 0.5rem 1.1rem;
+		border-radius: 8px;
+	}
+	.add-col-group {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+	.add-col-input {
+		padding: 0.5rem 0.9rem;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+		font-size: 1rem;
+		min-width: 180px;
+		transition: border-color 0.15s;
+	}
+	.add-col-input:focus {
+		border-color: #4a90e2;
+		outline: none;
+	}
+	.add-col-btn {
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: 1rem;
+		padding: 0.5rem 1.1rem;
+		border-radius: 8px;
+	}
+
+	.bulk-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem 0.6rem;
+		margin: 0.5rem 0;
+		border: 1px solid #e5e5e5;
+		border-radius: 6px;
+		background: #fbfbfb;
+	}
+	.bulk-toolbar .danger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		color: #a11;
+	}
+	.bulk-toolbar .link {
+		background: transparent;
+		border: none;
+		color: #555;
+		text-decoration: underline;
+		padding: 0;
+	}
+
+	.select-col {
+		width: 36px;
+		text-align: center;
+	}
+
+	.header-cell {
+		cursor: pointer;
+		user-select: none;
+		white-space: nowrap;
+	}
+	.header-cell.editing {
+		cursor: text;
+	}
+	.header-input {
+		width: 100%;
+		box-sizing: border-box;
+		padding: 4px 6px;
+		border: 1px solid #4a90e2;
+		border-radius: 4px;
+		font: inherit;
+		color: inherit;
+		background: #fff;
+	}
+
+	.header-menu {
+		position: fixed;
+		min-width: 200px;
+		max-width: 260px;
+		background: #fff;
+		border: 1px solid #e5e5e5;
+		border-radius: 8px;
+		box-shadow: 0 10px 24px rgba(0, 0, 0, 0.15);
+		padding: 6px;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		z-index: 9999;
+	}
+	.header-menu .menu-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 10px;
+		border: none;
+		background: transparent;
+		text-align: left;
+		width: 100%;
+		border-radius: 6px;
+		font-size: 0.95rem;
+		color: #222;
+		transition:
+			background-color 0.15s ease,
+			color 0.15s ease;
+	}
+	.header-menu .menu-item:hover,
+	.header-menu .menu-item:focus {
+		background: #f6f6f6;
+		outline: none;
+	}
+	.header-menu .menu-item.danger {
+		color: #a11;
+	}
+	.header-menu .menu-item.danger:hover,
+	.header-menu .menu-item.danger:focus {
+		background: #fff3f3;
+	}
+
+	.pagination {
+		margin: 0.5rem 0;
+		display: flex;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+		align-items: center;
+	}
+	.rows-group {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.25rem 0.75rem;
+		background: #f6f6f6;
+		border-radius: 8px;
+		border: 1px solid #e1e1e1;
+	}
+	.rows-label {
+		font-weight: 500;
+		color: #333;
+		font-size: 1rem;
+		margin-right: 0.1rem;
+	}
+	.rows-select {
+		padding: 0.45rem 1.1rem 0.45rem 0.7rem;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+		background: #fff;
+		font-size: 1rem;
+		color: #222;
+		transition: border-color 0.15s;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+		cursor: pointer;
+	}
+	.rows-select:focus {
+		border-color: #4a90e2;
+		outline: none;
+	}
+</style>

--- a/src/lib/components/dataLab/DataLab.svelte
+++ b/src/lib/components/dataLab/DataLab.svelte
@@ -17,6 +17,7 @@
 		type FilterOp
 	} from '$lib/utils/datalab/transform';
 	import type { RowAggOp } from '$lib/utils/datalab/transform';
+	import { downloadCSVFromParsed } from '$lib/utils/csv/export'; // NEW
 
 	// Working pipeline
 	let transforms = $state<Transform[]>([]);
@@ -515,6 +516,13 @@
 	function backToProjects() {
 		activeFileId.set(null);
 	}
+
+	// Export the currently shown dataset (preview or base)
+	function exportCSV() {
+		const data = tableData;
+		if (!data) return;
+		downloadCSVFromParsed(data);
+	}
 </script>
 
 <svelte:window onkeydown={onKey} onclick={() => (headerMenu = null)} />
@@ -822,6 +830,10 @@
 						disabled={!baseData || !!preview}
 					>
 						{editMode ? 'Editing (on)' : 'Edit mode'}
+					</button>
+					<button class="secondary" onclick={exportCSV} title="Export CSV" disabled={!tableData}>
+						<span class="material-symbols-outlined">file_download</span>
+						Export
 					</button>
 					{#if preview && !editMode}
 						<small class="muted">Editing disabled while preview is active</small>

--- a/src/lib/components/projects/FileTabs.svelte
+++ b/src/lib/components/projects/FileTabs.svelte
@@ -4,8 +4,94 @@
 	import { filesState, setFileState } from '$lib/stores/csvMulti';
 	import { parseCSVFile } from '$lib/utils/csv/csv';
 
-	let fileInput: HTMLInputElement | null = null;
-	let saving = false;
+	let fileInput = $state<HTMLInputElement | null>(null);
+	let saving = $state(false);
+
+	// Deletion state
+	let deletingFileId = $state<string | null>(null);
+	let deleting = $state(false);
+	let deleteError = $state<string | null>(null);
+	let deleteDialogPos = $state<{ x: number; y: number } | null>(null);
+	let deleteDismissTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// NEW: dialog element ref for focus
+	let deleteDialogEl = $state<HTMLDivElement | null>(null);
+
+	const deletingMeta = $derived(() => {
+		if (!deletingFileId) return null;
+		return $projectFiles.find((f) => f.file_id === deletingFileId) ?? null;
+	});
+
+	function startDelete(id: string, evt: MouseEvent) {
+		deleteError = null;
+		deletingFileId = id;
+
+		// Cursor position (adjust to stay in viewport)
+		const margin = 12;
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		let x = evt.clientX;
+		let y = evt.clientY;
+
+		const approxWidth = 300;
+		const approxHeight = 150;
+		if (x + approxWidth + margin > vw) x = vw - approxWidth - margin;
+		if (y + approxHeight + margin > vh) y = vh - approxHeight - margin;
+		if (x < margin) x = margin;
+		if (y < margin) y = margin;
+
+		deleteDialogPos = { x, y };
+
+		// Auto-dismiss after 5s
+		if (deleteDismissTimer) clearTimeout(deleteDismissTimer);
+		deleteDismissTimer = setTimeout(() => {
+			cancelDelete();
+		}, 5000);
+	}
+
+	function clearDeleteTimer() {
+		if (deleteDismissTimer) {
+			clearTimeout(deleteDismissTimer);
+			deleteDismissTimer = null;
+		}
+	}
+
+	function cancelDelete() {
+		clearDeleteTimer();
+		deletingFileId = null;
+		deleteError = null;
+		deleteDialogPos = null;
+	}
+
+	async function confirmDeleteFile() {
+		if (!deletingFileId) return;
+		clearDeleteTimer();
+		deleting = true;
+		deleteError = null;
+		try {
+			const res = await fetch(`/api/files/${deletingFileId}`, {
+				method: 'DELETE',
+				credentials: 'same-origin'
+			});
+			if (!res.ok) {
+				deleteError = 'Failed to delete file';
+				return;
+			}
+			if ($activeFileId === deletingFileId) {
+				activeFileId.set(null);
+			}
+			await refreshFiles();
+			if ($projectFiles.length > 0) {
+				activeFileId.set($projectFiles[0].file_id);
+			}
+		} catch (e: any) {
+			deleteError = e?.message ?? 'Error deleting file';
+		} finally {
+			deleting = false;
+			deletingFileId = null;
+			deleteDialogPos = null;
+		}
+	}
 
 	async function openUpload() {
 		fileInput?.click();
@@ -15,10 +101,8 @@
 		const input = e.target as HTMLInputElement;
 		if (!input.files || input.files.length === 0 || !$currentProject) return;
 		const file = input.files[0];
-
 		try {
 			const parsed = await parseCSVFile(file, { useHeader: true });
-			// Create a file on the server with initial snapshot at seq=0
 			const res = await fetch(`/api/projects/${$currentProject.project_id}/files`, {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
@@ -30,10 +114,8 @@
 				})
 			});
 			if (!res.ok) throw new Error('Failed to create file');
-			const created = await res.json(); // { file_id, name, ... }
-			// refresh files list
+			const created = await res.json();
 			await refreshFiles();
-			// set state locally and activate tab
 			setFileState(created.file_id, { ...parsed, loadedAt: new Date().toISOString() });
 			activeFileId.set(created.file_id);
 		} catch (err: any) {
@@ -55,7 +137,6 @@
 
 	async function loadTab(fileId: string) {
 		activeFileId.set(fileId);
-		// If state not loaded yet, fetch snapshot
 		if (!$filesState[fileId]) {
 			const res = await fetch(`/api/files/${fileId}/state`, {
 				credentials: 'same-origin'
@@ -90,72 +171,196 @@
 		}
 	}
 
-	$: ($currentProject, $projectFiles, $activeFileId, $filesState); // subscribe
+	function onWindowClick(e: MouseEvent) {
+		if (!deletingFileId) return;
+		const target = e.target as HTMLElement;
+		if (target.closest('.delete-dialog') || target.closest('.tab-del')) return;
+		cancelDelete();
+	}
+
+	// Replace legacy $: subscription with an empty effect (keeps stores live if needed)
+	$effect(() => {
+		$currentProject;
+		$projectFiles;
+		$activeFileId;
+		$filesState;
+	});
+
 	onMount(refreshFiles);
+
+	// NEW: ensure dialog key handler exists
+	function onDialogKey(e: KeyboardEvent) {
+		if (!deleteDialogEl) return;
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			cancelDelete();
+			return;
+		}
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			confirmDeleteFile();
+			return;
+		}
+		if (e.key === 'Tab') {
+			const focusables = Array.from(deleteDialogEl.querySelectorAll<HTMLElement>('button'));
+			if (focusables.length === 0) return;
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			const active = document.activeElement as HTMLElement | null;
+			if (e.shiftKey && active === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && active === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+
+	// Focus dialog when it mounts
+	$effect(() => {
+		if (deleteDialogEl) queueMicrotask(() => deleteDialogEl?.focus());
+	});
 </script>
+
+<svelte:window on:click={onWindowClick} />
 
 {#if $currentProject && $projectFiles.length > 0}
 	<div class="tabs-bar" aria-label="Files">
 		<div class="tabs">
 			{#each $projectFiles as f}
-				<button
-					class="tab"
-					class:active={$activeFileId === f.file_id}
-					on:click={() => loadTab(f.file_id)}
-					title={f.original_filename ?? f.name}
-				>
-					{f.name}
-				</button>
+				<div class="tab-wrap">
+					<button
+						class="tab"
+						class:active={$activeFileId === f.file_id}
+						onclick={() => loadTab(f.file_id)}
+						title={f.original_filename ?? f.name}
+						aria-label={`Open file ${f.name}`}
+					>
+						<span class="tab-label">{f.name}</span>
+					</button>
+					<button
+						class="tab-del"
+						title={`Delete ${f.name}`}
+						aria-label={`Delete ${f.name}`}
+						onclick={(e) => startDelete(f.file_id, e)}
+					>
+						<span class="material-symbols-outlined">delete</span>
+					</button>
+				</div>
 			{/each}
-
 			<button
 				class="add-btn"
-				on:click={openUpload}
+				onclick={openUpload}
 				title="Add file to project"
 				aria-label="Add file"
 			>
 				<span class="material-symbols-outlined">add</span>
 			</button>
 		</div>
-
-		<!-- Add file button -->
-
-		<!-- Hidden input for CSV upload -->
 		<input
 			bind:this={fileInput}
 			type="file"
 			accept=".csv,text/csv"
 			class="visually-hidden"
-			on:change={onUpload}
+			onchange={onUpload}
 		/>
 	</div>
+
+	{#if deletingFileId && deletingMeta && deleteDialogPos}
+		<div
+			class="delete-dialog floating"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Confirm delete file"
+			style="left:{deleteDialogPos.x}px; top:{deleteDialogPos.y}px"
+			tabindex="-1"
+			bind:this={deleteDialogEl}
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={onDialogKey}
+		>
+			<p class="dlg-text">
+				Delete <strong>{deletingMeta.name}</strong>? This cannot be undone.
+			</p>
+			{#if deleteError}<p class="error">{deleteError}</p>{/if}
+			<div class="dialog-actions">
+				<button class="btn subtle" onclick={cancelDelete} disabled={deleting}>Cancel</button>
+				<button class="btn danger-outline" onclick={confirmDeleteFile} disabled={deleting}>
+					{deleting ? 'Deleting…' : 'Delete'}
+				</button>
+			</div>
+			<small class="autodismiss-note">(Esc to cancel)</small>
+		</div>
+	{/if}
 {/if}
 
 <style>
 	.tabs-bar {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		gap: 8px;
 		margin: 8px 0;
+		flex-wrap: wrap;
 	}
 	.tabs {
 		display: flex;
 		gap: 6px;
 		flex-wrap: wrap;
+		align-items: flex-start;
+	}
+
+	.tab-wrap {
+		display: inline-flex;
+		align-items: stretch;
+		position: relative;
+		border-radius: 8px;
+		overflow: hidden;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
 	}
 	.tab {
 		padding: 6px 10px;
 		border: 1px solid #ddd;
 		background: #f7f7f7;
-		border-radius: 8px;
+		border-radius: 8px 0 0 8px;
 		cursor: pointer;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		border-right: none;
 	}
 	.tab.active {
 		background: #eaf2ff;
 		border-color: #bcd3ff;
 	}
+	.tab-del {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 34px;
+		border: 1px solid #ddd;
+		border-left: none;
+		background: #fff;
+		cursor: pointer;
+		border-radius: 0 8px 8px 0;
+		color: #666;
+		transition:
+			background 0.15s,
+			color 0.15s;
+	}
+	.tab-del:hover {
+		background: #f2f2f2;
+		color: #b22;
+	}
+	.tab-wrap:hover .tab-del {
+		opacity: 1;
+	}
+	.tab-label {
+		max-width: 140px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 
-	/* + button styled to match your UI (outline + Material icon) */
 	.add-btn {
 		display: inline-flex;
 		align-items: center;
@@ -172,6 +377,7 @@
 	.add-btn:hover {
 		background: #f8f9ff;
 	}
+
 	.material-symbols-outlined {
 		font-variation-settings:
 			'FILL' 0,
@@ -192,5 +398,72 @@
 		clip: rect(0 0 0 0);
 		white-space: nowrap;
 		border: 0;
+	}
+
+	.delete-dialog {
+		border: 1px solid #d4d4d4;
+		background: #fff;
+		padding: 10px 12px 12px;
+		border-radius: 8px;
+		max-width: 300px;
+		box-shadow: 0 4px 14px rgba(0, 0, 0, 0.1);
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		font-size: 0.85rem;
+	}
+	.delete-dialog.floating {
+		position: fixed;
+		z-index: 50;
+	}
+	.autodismiss-note {
+		font-size: 0.65rem;
+		color: #777;
+		align-self: flex-end;
+		margin-top: -4px;
+	}
+	.dlg-text {
+		margin: 0;
+		line-height: 1.3;
+	}
+	.dialog-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 6px;
+	}
+	.btn.subtle {
+		min-height: 30px;
+		padding: 4px 12px;
+		border-radius: 6px;
+		border: 1px solid #c8c8c8;
+		background: #fafafa;
+		cursor: pointer;
+		font-size: 0.75rem;
+	}
+	.btn.subtle:hover:not(:disabled) {
+		background: #f0f0f0;
+	}
+	.btn.danger-outline {
+		min-height: 30px;
+		padding: 4px 14px;
+		border-radius: 6px;
+		border: 1px solid #c88;
+		background: #fff;
+		color: #a02222;
+		font-weight: 500;
+		cursor: pointer;
+		font-size: 0.75rem;
+	}
+	.btn.danger-outline:hover:not(:disabled) {
+		background: #fff6f6;
+	}
+	.btn.danger-outline:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+	.error {
+		color: #b00020;
+		font-size: 0.7rem;
+		margin: 0;
 	}
 </style>

--- a/src/lib/components/projects/ProjectBar.svelte
+++ b/src/lib/components/projects/ProjectBar.svelte
@@ -41,7 +41,6 @@
 	}
 
 	async function loadFileState(fileId: string) {
-		// GET last snapshot (ignore ops for now)
 		const res = await fetch(`/api/files/${fileId}/state`);
 		if (!res.ok) return;
 		const data = await res.json();
@@ -69,35 +68,128 @@
 		await selectProject(created.project_id);
 	}
 
-	$: $currentProject; // subscribe
+	$: $currentProject; // subscribe to store
 	onMount(fetchProjects);
 </script>
 
 <div class="project-bar">
-	<label for="project-select">Project:</label>
-	<select
-		id="project-select"
-		disabled={loading || projects.length === 0}
-		on:change={(e) => selectProject((e.target as HTMLSelectElement).value)}
-	>
-		{#if !projects.length}<option>(no projects)</option>{/if}
-		{#each projects as p}
-			<option value={p.project_id} selected={$currentProject?.project_id === p.project_id}>
-				{p.name}
-			</option>
-		{/each}
-	</select>
-	<button on:click={createProject}>New project</button>
+	<div class="col">
+		<label class="label" for="project-select">Project</label>
+		<div class="selector-group">
+			<select
+				id="project-select"
+				class="project-select"
+				disabled={loading || projects.length === 0}
+				on:change={(e) => selectProject((e.target as HTMLSelectElement).value)}
+				aria-label="Select project"
+			>
+				{#if !projects.length}<option>(no projects)</option>{/if}
+				{#each projects as p}
+					<option value={p.project_id} selected={$currentProject?.project_id === p.project_id}>
+						{p.name}
+					</option>
+				{/each}
+			</select>
+			<button class="btn primary grouped" on:click={createProject} title="Create a new project">
+				<span class="material-symbols-outlined">add</span>
+				<span>New</span>
+			</button>
+		</div>
+		{#if $currentProject}
+			<small class="muted">Selected: {$currentProject.name}</small>
+		{/if}
+	</div>
 </div>
 
-<style>
+<style lang="scss">
+	@use '../../../styles/global.scss' as global;
+
 	.project-bar {
 		display: flex;
-		gap: 8px;
+		gap: 12px;
 		align-items: center;
-		margin-bottom: 8px;
+		margin-bottom: 12px;
 	}
-	select {
-		padding: 6px 8px;
+
+	.col {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.label {
+		font-weight: 600;
+	}
+
+	/* Match CsvHome.svelte */
+	.selector-group {
+		display: inline-flex;
+		align-items: stretch;
+		border: 1px solid global.$text-grey-10;
+		border-radius: 10px;
+		overflow: hidden;
+		background: #fff;
+		box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+	}
+	.project-select {
+		padding: 0 12px;
+		min-width: 280px;
+		height: 40px;
+		border: none;
+		background: #fff;
+		color: #222;
+	}
+	.project-select:focus-visible {
+		outline: 3px solid global.$background-primary-color;
+		outline-offset: 2px;
+	}
+
+	.btn {
+		min-height: 40px;
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		border-radius: 10px;
+		padding: 8px 12px;
+		border: 1px solid global.$text-grey-10;
+		background: #fff;
+		color: #222;
+		cursor: pointer;
+	}
+	.btn.primary {
+		background: global.$background-primary-color;
+		color: global.$text-white;
+		border-color: global.$text-grey-10;
+		box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+	}
+	.btn.primary:hover {
+		background: global.$background-secondary-color;
+		border-color: global.$background-primary-color;
+		color: global.$text-grey-90;
+		box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
+	}
+
+	.btn.primary.grouped {
+		border-radius: 0 10px 10px 0;
+		border: none;
+		padding: 0 12px;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		border-left: 1px solid global.$text-grey-10;
+	}
+
+	.muted {
+		color: #666;
+	}
+
+	.material-symbols-outlined {
+		font-variation-settings:
+			'FILL' 0,
+			'wght' 500,
+			'GRAD' 0,
+			'opsz' 24;
+		font-size: 20px;
+		line-height: 1;
 	}
 </style>

--- a/src/lib/utils/datalab/transform.ts
+++ b/src/lib/utils/datalab/transform.ts
@@ -1,0 +1,120 @@
+import type { ParsedCSV, CellValue } from '$lib/stores/csvData';
+
+export type FilterOp = 'eq' | 'neq' | 'contains' | 'in';
+
+export type Transform =
+  | { kind: 'filterRows'; column: string; op: FilterOp; value: string | string[]; caseSensitive?: boolean }
+  | { kind: 'rowAverage'; columns: string[]; outColumn: string }
+  | { kind: 'appendFile'; other: ParsedCSV };
+
+export function applyTransforms(base: ParsedCSV, transforms: Transform[]): ParsedCSV {
+  let cur: ParsedCSV = cloneCSV(base);
+
+  for (const t of transforms) {
+    switch (t.kind) {
+      case 'filterRows':
+        cur = filterRows(cur, t);
+        break;
+      case 'rowAverage':
+        cur = rowAverage(cur, t.columns, t.outColumn);
+        break;
+      case 'appendFile':
+        cur = appendFile(cur, t.other);
+        break;
+    }
+  }
+
+  const label = summarizeTransforms(transforms);
+  return {
+    ...cur,
+    filename: label ? `${base.filename} | ${label}` : base.filename
+  };
+}
+
+export function summarizeTransforms(transforms: Transform[]): string {
+  return transforms
+    .map((t) => {
+      switch (t.kind) {
+        case 'filterRows': {
+          const v = Array.isArray(t.value) ? `[${t.value.join(', ')}]` : JSON.stringify(t.value);
+          return `Filter: ${t.column} ${t.op} ${v}`;
+        }
+        case 'rowAverage':
+          return `RowAvg(${t.columns.join(',')}) -> ${t.outColumn}`;
+        case 'appendFile':
+          return `Append(${t.other.filename})`;
+      }
+    })
+    .join(' + ');
+}
+
+function cloneCSV(csv: ParsedCSV): ParsedCSV {
+  return {
+    ...csv,
+    headers: [...csv.headers],
+    rows: csv.rows.map((r) => ({ ...r })),
+    columnTypes: csv.columnTypes ? { ...csv.columnTypes } : undefined
+  };
+}
+
+function normalizeString(input: unknown, caseSensitive?: boolean): string {
+  const s = input == null ? '' : String(input);
+  return caseSensitive ? s : s.toLowerCase();
+}
+
+function filterRows(csv: ParsedCSV, t: Extract<Transform, { kind: 'filterRows' }>): ParsedCSV {
+  const { column, op, value, caseSensitive } = t;
+  const outRows = csv.rows.filter((row) => {
+    const raw = row[column];
+    const a = normalizeString(raw, caseSensitive);
+    if (op === 'eq') return a === normalizeString(value as string, caseSensitive);
+    if (op === 'neq') return a !== normalizeString(value as string, caseSensitive);
+    if (op === 'contains') return a.includes(normalizeString(value as string, caseSensitive));
+    if (op === 'in') {
+      const arr = Array.isArray(value) ? value : String(value).split(',').map((x) => x.trim());
+      const set = new Set(arr.map((x) => normalizeString(x, caseSensitive)));
+      return set.has(a);
+    }
+    return true;
+  });
+
+  return { ...csv, rows: outRows };
+}
+
+function toNumber(v: CellValue): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return v;
+  const n = Number(v as any);
+  return Number.isFinite(n) ? n : null;
+}
+
+function rowAverage(csv: ParsedCSV, columns: string[], outColumn: string): ParsedCSV {
+  const headers = csv.headers.includes(outColumn) ? csv.headers : [...csv.headers, outColumn];
+  const rows = csv.rows.map((r) => {
+    let sum = 0;
+    let cnt = 0;
+    for (const c of columns) {
+      const n = toNumber(r[c] ?? null);
+      if (n != null) { sum += n; cnt++; }
+    }
+    const avg = cnt > 0 ? sum / cnt : null;
+    return { ...r, [outColumn]: avg as any };
+  });
+  return { ...csv, headers, rows };
+}
+
+function appendFile(a: ParsedCSV, b: ParsedCSV): ParsedCSV {
+  const headersSet = new Set<string>(a.headers);
+  const headers: string[] = [...a.headers];
+  for (const h of b.headers) if (!headersSet.has(h)) { headersSet.add(h); headers.push(h); }
+
+  const rowsA = a.rows.map((r) => normalizeRow(r, headers));
+  const rowsB = b.rows.map((r) => normalizeRow(r, headers));
+  return { ...a, headers, rows: [...rowsA, ...rowsB] };
+}
+
+function normalizeRow(row: Record<string, CellValue>, headers: string[]) {
+  const out: Record<string, CellValue> = {};
+  for (const h of headers) out[h] = row[h] ?? null;
+  return out;
+}

--- a/src/routes/api/files/[fileId]/+server.ts
+++ b/src/routes/api/files/[fileId]/+server.ts
@@ -1,0 +1,24 @@
+import type { RequestHandler } from './$types';
+import DB from '$lib/common/DB_Postgresql';
+
+// DELETE /api/files/:fileId  (remove a file + cascades)
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+  const userId = locals.user?.user_id;
+  if (!userId) return new Response('Unauthorized', { status: 401 });
+  const db = DB();
+
+  // Ensure user is a member of the project owning this file
+  const { rows } = await db.query(
+    `SELECT f.project_id, f.name
+     FROM data.project_files f
+     JOIN data.project_members m ON m.project_id = f.project_id
+     WHERE f.file_id = $1 AND m.user_id = $2
+     LIMIT 1`,
+    [params.fileId, userId]
+  );
+  if (!rows.length) return new Response('Not found', { status: 404 });
+
+  await db.query(`DELETE FROM data.project_files WHERE file_id = $1`, [params.fileId]);
+  // Cascades remove snapshots & ops via FK ON DELETE CASCADE
+  return new Response(null, { status: 204 });
+};

--- a/src/routes/dataLab/+page.svelte
+++ b/src/routes/dataLab/+page.svelte
@@ -7,9 +7,6 @@
 </script>
 
 <div class="page">
-	<!-- Project picker (select/create project) -->
-	<ProjectBar />
-
 	{#if $currentProject && $projectFiles.length > 0}
 		<FileTabs />
 	{/if}

--- a/src/routes/dataLab/+page.svelte
+++ b/src/routes/dataLab/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import FileTabs from '$lib/components/projects/FileTabs.svelte';
+	import DataLab from '$lib/components/dataLab/DataLab.svelte';
+	import { activeFileId, projectFiles, currentProject } from '$lib/stores/project';
+</script>
+
+<div class="page">
+	{#if $currentProject && $projectFiles.length > 0}
+		<FileTabs />
+	{/if}
+
+	{#if $activeFileId}
+		<DataLab />
+	{:else}
+		<p style="padding:12px">Upload or open a file first.</p>
+	{/if}
+</div>
+
+<style>
+	.page {
+		padding: 12px;
+	}
+</style>

--- a/src/routes/dataLab/+page.svelte
+++ b/src/routes/dataLab/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import FileTabs from '$lib/components/projects/FileTabs.svelte';
 	import DataLab from '$lib/components/dataLab/DataLab.svelte';
+	import ProjectBar from '$lib/components/projects/ProjectBar.svelte';
+	import CsvHome from '$lib/components/CsvHome/CsvHome.svelte';
 	import { activeFileId, projectFiles, currentProject } from '$lib/stores/project';
 </script>
 
 <div class="page">
+	<!-- Project picker (select/create project) -->
+	<ProjectBar />
+
 	{#if $currentProject && $projectFiles.length > 0}
 		<FileTabs />
 	{/if}
@@ -12,7 +17,8 @@
 	{#if $activeFileId}
 		<DataLab />
 	{:else}
-		<p style="padding:12px">Upload or open a file first.</p>
+		<!-- Let users upload/open files in this route too -->
+		<CsvHome />
 	{/if}
 </div>
 


### PR DESCRIPTION
Title DataLab UX upgrades, safe tab deletion, preview/export fixes, and runes compliance

Summary This MR refines the end-to-end workflow: Project → CSV Parser (clean) → Data Lab (manipulate) → Export. It adds collapsible tools and a top “Pipeline” card in Data Lab, fixes tab-switch preview/highlight leakage, introduces CSV export, and implements safe file deletion from FileTabs with a confirmation dialog and API. Code is updated to Svelte 5 runes (no legacy $:).

Key changes

DataLab

Tools UX: Filter, Column aggregate, Row aggregate, Append are collapsible; Pipeline is a non-collapsible tool card at the top.
Row aggregate: generic rowAggregate with operations avg, sum, min, max, median, countNonNull; toggle columns and name an output column.
Column aggregate: compute a single value over current dataset, save result as a new tab.
Preview isolation: track previewFileId; preview clears when switching tabs to prevent stale preview showing on other files.
Highlights reset: clear highlightedRows/cells, selection, and editing state on tab switch.
Export: Export button downloads the currently visible dataset (preview if active, else base).
Top bar: “Projects” button (like Csvparser) and current file name chip.
Style: consistent button/input styles with CsvHome; header actions menu with accessibility tweaks.
CsvParser

Highlights reset on tab switch (no leaking empty/duplicate highlighting to other files).
“Open in Data Lab” button (reuses active file).
FileTabs

File deletion: per-tab delete button shows a low-key floating confirmation near click; auto-dismiss in 5s; closes on outside click or Esc; focusable and keyboard-accessible.
Runes compliance: converted refs and state to $state/$effect/$derived; removed legacy $:; fixed invalid attribute modifiers.
Auto-select next available file after deletion; clear activeFileId if the active file is removed.
API

DELETE /api/files/:fileId endpoint
Validates user membership in the file’s project.
Deletes the file record; assumes FK cascades remove snapshots/ops.
Returns 204 on success.
Implementation notes

Svelte 5 runes

Replaced legacy reactive statements ($:) with $effect/$derived/$derived.by.
DOM refs (bind:this) use $state to avoid non_reactive_update warnings.
Replaced invalid attribute modifiers with inline onclick handlers and manual stopPropagation.
Dialog accessibility: role=dialog, tabindex=-1, focus management, Esc handling, simple focus trap.
Data integrity/UX

Preview: only shows when previewFileId === $activeFileId.
Clearing UI state on activeFileId change avoids per-file bleed.
Delete dialog: subtle styling, no “type name to confirm” (per request), positioned near cursor.
Schema/assumptions

Endpoint relies on:
data.project_files table with FK cascades to related snapshots/ops.
data.project_members table to validate access.
No schema migration included in this MR; ensure these tables and constraints exist.
Affected files (high level)

src/lib/components/dataLab/DataLab.svelte
src/lib/components/csvParser/CsvParser.svelte
src/lib/components/projects/FileTabs.svelte
src/lib/components/projects/ProjectBar.svelte
src/lib/utils/datalab/transform.ts
src/routes/dataLab/+page.svelte
src/routes/api/files/[fileId]/+server.ts
How to test

Project and tabs
Create project, upload two CSVs. Ensure tabs render; switching tabs loads file states when needed.
CsvParser highlight reset
Open CSV A, use Clean panel to highlight duplicates/empties.
Switch to CSV B: previous highlights must not appear.
Return to A: highlights should be gone (expected).
DataLab transforms and preview isolation
Open CSV A in DataLab, add Filter/Row/Column aggregate transforms, Preview.
Switch to CSV B: A’s preview should not show in B.
Switch back: preview cleared (intended), transforms preserved.
Export
In DataLab, click Export. If preview is active: exported CSV matches preview; else exports base dataset.
Column aggregate save
Compute sum/max/etc. of a column and save. New tab appears, auto-selects; content is a single value column.
File deletion
Click trash on a tab. Floating confirm should appear near cursor, close on outside click or after ~5s, and support Esc/Enter.
Confirm delete: tab removed; if it was active, activeFileId cleared or next tab selected.
API returns 204; membership enforced (try with a user not in project if applicable).
Accessibility/keyboard
Delete dialog focuses on open; Tab cycles within dialog buttons; Esc closes.